### PR TITLE
Attach to event 'exit(code,signal)' instead of 'close()'.

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function moveDirAcrossDevice(source, dest, cb) {
   stdout = [];
   child.stderr.on('data', function(data) { stderr.push(data); });
   child.stdout.on('data', function(data) { stdout.push(data); });
-  child.on('close', function(code) {
+  child.on('exit', function(code) {
     if (code === 0) {
       cb();
     } else {


### PR DESCRIPTION
According to node process docs, the event "close" does not yield error codes, but "exit" does.

http://nodejs.org/api/process.html
