### PR TITLE
Cleaned up with JSHint

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,14 +13,14 @@ module.exports = function mv(source, dest, cb){
       } else if (stats.isDirectory()) {
         moveDirAcrossDevice(source, dest, cb);
       } else {
-        var err;
-        err = new Error("source must be file or directory");
-        err.code = 'NOTFILEORDIR';
-        cb(err);
+        var err2;
+        err2 = new Error("source must be file or directory");
+        err2.code = 'NOTFILEORDIR';
+        cb(err2);
       }
     });
   });
-}
+};
 
 function moveFileAcrossDevice(source, dest, cb) {
   var ins, outs;


### PR DESCRIPTION
I used [JSHint](http://jshint.com/) to look for potential sources of bugs. I ran `jshint .`, and only two warnings were found!
- `err` conflicted with another `err` object in the same scope
- forgotten semicolon when `mv` is exported.

Now node-mv passes JSHint linting!
