### PR TITLE
update ncp version to fix bugs that occur from in the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mv",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "fs.rename but works across devices. same as the unix utility 'mv'",
   "main": "index.js",
   "scripts": {
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "mkdirp": "~0.5.0",
-    "ncp": "~0.6.0",
+    "ncp": "2.0.0",
     "rimraf": "~2.2.8"
   },
   "bugs": {


### PR DESCRIPTION
Browser projects that include this project are unable to run in IE10 and below because of a dependency on an old version of NCP (https://www.npmjs.com/package/ncp)

https://github.com/trentm/node-bunyan/issues/213