### PR TITLE
remove need for mkdirp

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ var fs = require('fs');
 var ncp = require('ncp').ncp;
 var path = require('path');
 var rimraf = require('rimraf');
-var mkdirp = require('mkdirp');
 
 module.exports = mv;
 
@@ -11,18 +10,18 @@ function mv(source, dest, options, cb){
     cb = options;
     options = {};
   }
-  var shouldMkdirp = !!options.mkdirp;
+  var shouldMkdirRecursive = !!options.recursive;
   var clobber = options.clobber !== false;
   var limit = options.limit || 16;
 
-  if (shouldMkdirp) {
+  if (shouldMkdirRecursive) {
     mkdirs();
   } else {
     doRename();
   }
 
   function mkdirs() {
-    mkdirp(path.dirname(dest), function(err) {
+    fs.mkdir(path.dirname(dest), { recursive: true }, function(err) {
       if (err) return cb(err);
       doRename();
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mv",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "fs.rename but works across devices. same as the unix utility 'mv'",
   "main": "index.js",
   "scripts": {
@@ -24,10 +24,9 @@
     "node": ">=0.8.0"
   },
   "devDependencies": {
-    "mocha": "~2.2.5"
+    "mocha": "^7.1.1"
   },
   "dependencies": {
-    "mkdirp": "~0.5.1",
     "ncp": "~2.0.0",
     "rimraf": "~2.4.0"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -48,8 +48,8 @@ describe("mv", function() {
     });
   });
 
-  it("should create directory structure when mkdirp option set", function (done) {
-    mv("test/a-file", "test/does/not/exist/a-file-dest", {mkdirp: true}, function (err) {
+  it("should create directory structure when recursive option set", function (done) {
+    mv("test/a-file", "test/does/not/exist/a-file-dest", {recursive: true}, function (err) {
       assert.ifError(err);
       fs.readFile("test/does/not/exist/a-file-dest", 'utf8', function (err, contents) {
         assert.ifError(err);


### PR DESCRIPTION
mkdirp had a vulnerability. Rather than fix it, am using node built in mkdir with {recursive: true}.

Sadly this means updating Mocha as that too uses mkdirp, which thus breaks your travis builds as they're run against very old node versions.