### PR TITLE
Update rimraf dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 var ncp = require('ncp').ncp;
 var path = require('path');
-var rimraf = require('rimraf');
+var { rimraf } = require('rimraf');
 var mkdirp = require('mkdirp');
 
 module.exports = mv;
@@ -89,17 +89,20 @@ function moveDirAcrossDevice(source, dest, clobber, limit, cb) {
     limit: limit,
   };
   if (clobber) {
-    rimraf(dest, { disableGlob: true }, function(err) {
-      if (err) return cb(err);
-      startNcp();
-    });
+    rimraf(dest, { disableGlob: true }).then(
+      () => startNcp(),
+      err => cb(err),
+    );
   } else {
     startNcp();
   }
   function startNcp() {
     ncp(source, dest, options, function(errList) {
       if (errList) return cb(errList[0]);
-      rimraf(source, { disableGlob: true }, cb);
+      rimraf(source, { disableGlob: true }).then(
+        () => cb(),
+        err => cb(err),
+      );
     });
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "mkdirp": "~0.5.1",
     "ncp": "~2.0.0",
-    "rimraf": "~2.4.0"
+    "rimraf": "~6.0.1"
   },
   "bugs": {
     "url": "https://github.com/andrewrk/node-mv/issues"

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 var fs = require('fs');
-var rimraf = require('rimraf');
+var { rimraf } = require('rimraf');
 var describe = global.describe;
 var it = global.it;
 var mv = require('../');
@@ -57,7 +57,7 @@ describe("mv", function() {
         // move it back
         mv("test/does/not/exist/a-file-dest", "test/a-file", function(err) {
           assert.ifError(err);
-          rimraf("test/does", { disableGlob: true }, done);
+          rimraf("test/does", { disableGlob: true }).then(done, done);
         });
       });
     });


### PR DESCRIPTION
Rimraf uses an outdated glob version. This PR fixes that.

Note that this marks `mv` as not supported for Node.js < 20, which means that it only supports currently supported Node.js versions.

@andrewrk I see you are busy doing zig and this project still uses travis. If you're open for it, I'd volunteer moving it to GH Actions in a separate PR (maybe to even merge it before this one, so we can have a working CI again).